### PR TITLE
Fix decoder issue. Remove use of unsafe. Introduce http4s.client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+project/project/

--- a/src/main/scala/com/womenwhocode/web/Webapp.scala
+++ b/src/main/scala/com/womenwhocode/web/Webapp.scala
@@ -1,37 +1,48 @@
 package com.womenwhocode.web
 
-import org.http4s._
-import org.http4s.circe.{jsonEncoderOf, jsonOf}
-import org.http4s.headers.`Content-Type`
 import io.circe.generic.auto._
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.circe._
 import org.http4s.client.blaze.PooledHttp1Client
 import org.http4s.dsl._
 
 import scalaz.concurrent.Task
 
 object Webapp {
-
   val httpClient = PooledHttp1Client()
 
   case class PostcodeResult(postcode: String, country: String, region: String, codes: CodeDetail)
-  case class PostcodeResponse(status: Int, result: PostcodeResult)
+  case class PostcodeResponse(result: PostcodeResult)
   case class CodeDetail(admin_district: String, admin_county: String)
   case class MultiPostcodeResponse(status: Int, result: List[PostcodeResult])
-
-  implicit val formats = org.json4s.DefaultFormats
+  case class BulkPostcodeResponse(status: Int, result: List[PostcodeResponse])
 
   implicit val decoder = jsonOf[PostcodeResponse]
   implicit val encoder = jsonEncoderOf[PostcodeResponse]
   implicit val multiDecoder = jsonOf[MultiPostcodeResponse]
   implicit val multiEncoder = jsonEncoderOf[MultiPostcodeResponse]
+  implicit val bulkDecoder = jsonOf[BulkPostcodeResponse]
   //implicit val postcodeMapEncoder = jsonEncoderOf[Map[String, List[String]]] //Solution: to using an encoder instead of Serialization directly
   implicit val postcodeMapEncoder = jsonEncoderOf[Map[String, List[(String, String)]]]
   implicit val multiPostcodeReqDecoder = jsonOf[Map[String, List[String]]]
   implicit val multiPostcodeReqEncoder = jsonEncoderOf[Map[String, List[String]]]
   implicit val ListEncoder = jsonEncoderOf[List[String]]
 
-  def responseJson(response: MultiPostcodeResponse) = {
+  def responseJson(response: MultiPostcodeResponse) =
     Map("postcodes" -> response.result.map(postcodeRes => (postcodeRes.postcode, postcodeRes.region)))
+
+  def responseJson(response: BulkPostcodeResponse) =
+    Map("postcodes" -> response.result.map(postcodeRes => (postcodeRes.result.postcode, postcodeRes.result.region)))
+
+  def get[A: EntityDecoder](query: String) =
+    httpClient.expect[A](s"http://api.postcodes.io/postcodes/$query")
+
+
+  def findPostcodes(postcodes: List[String]) = {
+    import org.http4s.client._
+    val req = POST(uri("http://api.postcodes.io/postcodes"), Map("postcodes" -> postcodes).asJson)
+    httpClient.expect[BulkPostcodeResponse](req)
   }
 
   val service = HttpService {
@@ -43,25 +54,20 @@ object Webapp {
       Ok(s"locations endpoint")
 
     case GET -> Root / "locations" / postcode =>
-      val getRequestTask = httpClient.expect[PostcodeResponse](s"http://api.postcodes.io/postcodes/${postcode}")
-      getRequestTask.flatMap(json => Ok(json))
+      Ok(get[PostcodeResponse](postcode))
 
     case GET -> Root / "locations" / postcode / "nearest" =>
-      val getRequestTask = httpClient.expect[MultiPostcodeResponse](s"http://api.postcodes.io/postcodes/${postcode}/nearest")
-      getRequestTask.flatMap(response => Ok(responseJson(response)))
+      for {
+        nearest <- get[MultiPostcodeResponse](s"$postcode/nearest")
+        resp <- Ok(responseJson(nearest))
+      } yield resp
 
-      //TODO: 1. Fix decoder issue with response, 2. don't use unsafePerformSync
     case req @ POST -> Root / "locations" / "bulk" =>
-      def findNearestPostcodes(postcodes: List[String]) = {
-        val body = Map("postcodes" -> postcodes)
-        val headers = Headers(`Content-Type`(MediaType.`application/json`, Charset.`UTF-8`))
-        val request = Request(method = Method.POST, uri = Uri.uri("http://api.postcodes.io/postcodes"), headers = headers)
-          .withBody(body)
-          .asInstanceOf[Task[Request]]
-        val postRequestTask = httpClient.expect[MultiPostcodeResponse](request)
-        postRequestTask.flatMap(response => Ok(responseJson(response)))
-      }
+      for {
+        json <- req.as[Map[String, List[String]]]
+        postcodes <- findPostcodes(json.head._2)
+        resp <- Ok(responseJson(postcodes))
+      } yield resp
 
-      findNearestPostcodes(req.as[Map[String, List[String]]].unsafePerformSync.head._2)
   }
 }

--- a/src/main/scala/com/womenwhocode/web/Webapp.scala
+++ b/src/main/scala/com/womenwhocode/web/Webapp.scala
@@ -7,8 +7,6 @@ import org.http4s.circe._
 import org.http4s.client.blaze.PooledHttp1Client
 import org.http4s.dsl._
 
-import scalaz.concurrent.Task
-
 object Webapp {
   val httpClient = PooledHttp1Client()
 


### PR DESCRIPTION
I've tried out a few things you'll want to review:

1. Factor client.expect call into function. Uses a context bound ([A:
EntityDecoder]) so may be too advanced
2. Use for comprehensions instead of .flatMap
3. Use http4s.client instead of Request().withBody()...