### PR TITLE
Specify version to ensure building with sbt gives consistent results

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15


### PR DESCRIPTION
_(hello, I'm a dev at the Guardian, I'll be helping with the WWC Scala Meet-Up on, er, Monday 3rd July!)_

Using sbt, it's encouraged to specify the precise version of sbt you want in the `project/build.properties` file. No matter what version of sbt you have installed, the sbt launcher will read the file and download the appropriate version if required. This allows people with different versions of sbt to build the project with consistent results - coping with the format of the sbt build config changing over time.

It might be you're aiming to keep the boilerplate in this project to a minimum to increase clarity? But if you can tolerate this one extra file, as a best-practice I'd recommend adding it.

http://www.scala-sbt.org/0.13/docs/Basic-Def.html#Specifying+the+sbt+version

